### PR TITLE
fix typo in gem version badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gem Version](https://badge.fury.io/rb/preservaton-client.svg)](https://badge.fury.io/rb/preservation-client)
+[![Gem Version](https://badge.fury.io/rb/preservation-client.svg)](https://badge.fury.io/rb/preservation-client)
 [![Build Status](https://travis-ci.org/sul-dlss/preservation-client.svg?branch=master)](https://travis-ci.org/sul-dlss/preservation-client)
 [![Maintainability](https://api.codeclimate.com/v1/badges/00d2d8957226777105b3/maintainability)](https://codeclimate.com/github/sul-dlss/preservation-client/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/00d2d8957226777105b3/test_coverage)](https://codeclimate.com/github/sul-dlss/preservation-client/test_coverage)


### PR DESCRIPTION
## Why was this change made?

To fix the gem badge on the README:

![image](https://user-images.githubusercontent.com/96775/65804974-bdc91180-e138-11e9-8e1c-6c87a17eed01.png)

## Was the documentation (README, API, wiki, consul, etc.) updated?

yup.