### PR TITLE
Remove env var from config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-env:
-  global:
-    - CC_TEST_REPORTER_ID=02e8afad8d0b699828dd69b6f45b598e7317b2d9828ea23380c3a97113068a0c
-
-dist: bionic
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
## Why was this change made?

The CC_TEST_REPORTER_ID variable is already configured via the TravisCI.org UI. 

Also, pushing this change up to verify that we are no longer building this project on both Pro and free-tier TravisCI.

## Was the documentation (README, API, wiki, consul, etc.) updated?

no