### PR TITLE
signature_catalog returns Moab::SignatureCatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ druids may be with or without the "druid:" prefix - 'oo000oo0000' or 'druid:oo00
 - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml')` - returns contents of identityMetadata.xml in most recent version of Moab object
   - You may specify the version:
     - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8')` - returns contents of identityMetadata.xml in version 8 of Moab object
-- `client.objects.signature_catalog(druid: 'oo000oo0000')` - returns contents of latest version of signatureCatalog.xml from Moab object
+- `client.objects.signature_catalog('oo000oo0000')` - returns latest Moab::SignatureCatalog from Moab, or new Moab::SignatureCatalog for Moab if none yet exists
+
 
 ### Get difference information between passed contentMetadata.xml and files in the Moab
 

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -70,10 +70,17 @@ module Preservation
         file(druid, 'metadata', filepath, version)
       end
 
-      # convenience method for retrieving latest signatureCatalog.xml file from a Moab object
+      # convenience method for retrieving latest Moab::SignatureCatalog from a Moab object,
+      #  or a newly minted Moab::SignatureCatalog if it doesn't yet exist
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
+      # @return [Moab::SignatureCatalog] the catalog of all files previously ingested
       def signature_catalog(druid)
-        manifest(druid: druid, filepath: 'signatureCatalog.xml')
+        Moab::SignatureCatalog.parse manifest(druid: druid, filepath: 'signatureCatalog.xml')
+      rescue Preservation::Client::UnexpectedResponseError => e
+        return Moab::SignatureCatalog.new(digital_object_id: druid, version_id: 0) if
+          e.message.match?('404 File Not Found')
+
+        raise
       end
 
       private


### PR DESCRIPTION
~~DO NOT MERGE:  it is unclear if this is moving in the right direction at the moment.~~

## Why was this change made?

The consumer of this method expects a Moab::SignatureCatalog object.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes, README