### PR TITLE
add shelve_content_diff and content_inventory_diff methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,32 @@ Note that the preservation service is behind a firewall.
 
 ## API Coverage
 
+### Get the current version of a preserved object (Moab)
+
 - Preservation::Client.objects.current_version('oo000oo0000')  (can also be 'druid:oo000oo0000')
-- Preservation::Client.objects.checksums(druids: druids) - will return raw csv
-- Preservation::Client.objects.checksums(druids: druids, format: 'json') - will return json
-- Preservation::Client.objects.content(druid: 'oo000oo0000', filepath: 'my_file.pdf') - will return contents of my_file.pdf in most recent version of Moab object
-- Preservation::Client.objects.content(druid: 'oo000oo0000', filepath: 'my_file.pdf', version: '1') - will return contents of my_file.pdf in version 1 of Moab object
-- Preservation::Client.objects.manifest(druid: 'oo000oo0000', filepath: 'versionInventory.xml') - will return contents of versionInventory.xml in most recent version of Moab object
-- Preservation::Client.objects.manifest(druid: 'oo000oo0000', filepath: 'versionInventory.xml', version: '3') - will return contents of versionInventory.xml in version 3 of Moab object
-- Preservation::Client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml') - will return contents of identityMetadata.xml in most recent version of Moab object
-- Preservation::Client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8') - will return contents of identityMetadata.xml in version 8 of Moab object
-- Preservation::Client.objects.signature_catalog(druid: 'oo000oo0000') - will return contents of latest version of signatureCatalog.xml from Moab object
+
+### Retrieve file signature (checksum) information
+
+- Preservation::Client.objects.checksums(druids: druids) - returns info as raw csv
+- Preservation::Client.objects.checksums(druids: druids, format: 'json') - returns info as json
+
+### Retrieve individual files from preservation
+
+- Preservation::Client.objects.content(druid: 'oo000oo0000', filepath: 'my_file.pdf') - returns contents of my_file.pdf in most recent version of Moab object
+- Preservation::Client.objects.content(druid: 'oo000oo0000', filepath: 'my_file.pdf', version: '1') - returns contents of my_file.pdf in version 1 of Moab object
+- Preservation::Client.objects.manifest(druid: 'oo000oo0000', filepath: 'versionInventory.xml') - returns contents of versionInventory.xml in most recent version of Moab object
+- Preservation::Client.objects.manifest(druid: 'oo000oo0000', filepath: 'versionInventory.xml', version: '3') - returns contents of versionInventory.xml in version 3 of Moab object
+- Preservation::Client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml') - returns contents of identityMetadata.xml in most recent version of Moab object
+- Preservation::Client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8') - returns contents of identityMetadata.xml in version 8 of Moab object
+- Preservation::Client.objects.signature_catalog(druid: 'oo000oo0000') - returns contents of latest version of signatureCatalog.xml from Moab object
+
+### Get difference information between passed contentMetadata.xml and files in the Moab
+
+- Preservation::Client.objects.content_inventory_diff(druid: 'oo000oo0000', content_metadata: '<contentMetadata>...</contentMetadata>') - returns Moab::FileInventoryDifference containing differences between passed content metadata and latest version for subset 'all' (all|shelve|preserve|publish)
+  - you can also specify the subset and/or the version:
+    - Preservation::Client.objects.content_inventory_diff(druid: 'oo000oo0000', subset: 'publish', version: '1', content_metadata: '<contentMetadata>...</contentMetadata>')
+
+- Preservation::Client.objects.shelve_content_diff(druid: 'oo000oo0000', content_metadata: '<contentMetadata>...</contentMetadata>') - returns Moab::FileGroupDifference containing differences between passed content metadata and latest version for subset 'shelve'
 
 ## Development
 

--- a/preservation-client.gemspec
+++ b/preservation-client.gemspec
@@ -30,13 +30,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_dependency 'faraday', '~> 0.15'
+  spec.add_dependency 'moab-versioning', '~> 4.3'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.74.0'
+  spec.add_development_dependency 'rubocop', '~> 0.77.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
## Why was this change made?

To replace cm-inv-diff API endpoint in sdr-services-app.   The new methods here will replace dor-services-app calling sdr-services-app cm-inv-diff.

This leverages the new "objects/content_diff" API endpoint added to preservation_catalog in PR sul-dlss/preservation_catalog/pull/1250

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes, README