### PR TITLE
Error for 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,28 @@ def client
 end
 ```
 
+OR
+
+```ruby
+require 'preservation/client'
+
+def initialize
+  Preservation::Client.configure(url: Settings.preservation_catalog.url)
+end
+
+def do_the_thing
+  current_version_as_integer = Preservation::Client.current_version('druid:oo000oo0000')
+end
+```
+
 Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**.
 
 Note that the preservation service is behind a firewall.
 
 ## API Coverage
 
-druids may be with or without the "druid:" prefix - 'oo000oo0000' or 'druid:oo000oo0000'
+- druids may be with or without the "druid:" prefix - 'oo000oo0000' or 'druid:oo000oo0000'
+- methods can be called as `client(instance).objects.method` or `Preservation::Client.objects.method`
 
 ### Get the current version of a preserved object (Moab)
 
@@ -67,8 +82,7 @@ druids may be with or without the "druid:" prefix - 'oo000oo0000' or 'druid:oo00
 - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml')` - returns contents of identityMetadata.xml in most recent version of Moab object
   - You may specify the version:
     - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8')` - returns contents of identityMetadata.xml in version 8 of Moab object
-- `client.objects.signature_catalog('oo000oo0000')` - returns latest Moab::SignatureCatalog from Moab, or new Moab::SignatureCatalog for Moab if none yet exists
-
+- `client.objects.signature_catalog('oo000oo0000')` - returns latest Moab::SignatureCatalog from Moab
 
 ### Get difference information between passed contentMetadata.xml and files in the Moab
 

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -71,16 +71,10 @@ module Preservation
       end
 
       # convenience method for retrieving latest Moab::SignatureCatalog from a Moab object,
-      #  or a newly minted Moab::SignatureCatalog if it doesn't yet exist
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
-      # @return [Moab::SignatureCatalog] the catalog of all files previously ingested
+      # @return [Moab::SignatureCatalog] the manifest of all files previously ingested
       def signature_catalog(druid)
         Moab::SignatureCatalog.parse manifest(druid: druid, filepath: 'signatureCatalog.xml')
-      rescue Preservation::Client::UnexpectedResponseError => e
-        return Moab::SignatureCatalog.new(digital_object_id: druid, version_id: 0) if
-          e.message.match?('404 File Not Found')
-
-        raise
       end
 
       private

--- a/lib/preservation/client/versioned_api_service.rb
+++ b/lib/preservation/client/versioned_api_service.rb
@@ -42,36 +42,30 @@ module Preservation
       # @param path [String] path to be appended to connection url (no leading slash)
       # @param params [Hash] optional params
       def get(path, params)
-        get_path = api_version.present? ? "#{api_version}/#{path}" : path
-        resp = connection.get get_path, params
-        return resp.body if resp.success?
-
-        errmsg = ResponseErrorFormatter
-                 .format(response: resp, client_method_name: caller_locations.first.label)
-        raise Preservation::Client::UnexpectedResponseError, errmsg
-      rescue Faraday::ResourceNotFound => e
-        errmsg = "HTTP GET to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
-        raise Preservation::Client::NotFoundError, errmsg
-      rescue Faraday::ParsingError, Faraday::RetriableResponse => e
-        errmsg = "HTTP GET to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
-        raise Preservation::Client::UnexpectedResponseError, errmsg
+        http_response(:get, path, params)
       end
 
       # @param path [String] path to be appended to connection url (no leading slash)
       # @param params [Hash] optional params
       def post(path, params)
-        post_path = api_version.present? ? "#{api_version}/#{path}" : path
-        resp = connection.post post_path, params
+        http_response(:post, path, params)
+      end
+
+      # @param method [Symbol] :get or :post
+      # @param path [String] path to be appended to connection url (no leading slash)
+      # @param params [Hash] optional params
+      def http_response(method, path, params)
+        req_path = api_version.present? ? "#{api_version}/#{path}" : path
+        resp = connection.send(method, req_path, params)
         return resp.body if resp.success?
 
-        errmsg = ResponseErrorFormatter
-                 .format(response: resp, client_method_name: caller_locations.first.label)
+        errmsg = ResponseErrorFormatter.format(response: resp, client_method_name: caller_locations.first.label)
         raise Preservation::Client::UnexpectedResponseError, errmsg
       rescue Faraday::ResourceNotFound => e
-        errmsg = "HTTP POST to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
+        errmsg = "HTTP #{method.to_s.upcase} to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::NotFoundError, errmsg
       rescue Faraday::ParsingError, Faraday::RetriableResponse => e
-        errmsg = "HTTP POST to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
+        errmsg = "HTTP #{method.to_s.upcase} to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::UnexpectedResponseError, errmsg
       end
     end

--- a/lib/preservation/client/versioned_api_service.rb
+++ b/lib/preservation/client/versioned_api_service.rb
@@ -60,7 +60,11 @@ module Preservation
         return resp.body if resp.success?
 
         errmsg = ResponseErrorFormatter.format(response: resp, client_method_name: caller_locations.first.label)
-        raise Preservation::Client::UnexpectedResponseError, errmsg
+        if resp.status == 404
+          raise Preservation::Client::NotFoundError, errmsg
+        else
+          raise Preservation::Client::UnexpectedResponseError, errmsg
+        end
       rescue Faraday::ResourceNotFound => e
         errmsg = "HTTP #{method.to_s.upcase} to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::NotFoundError, errmsg

--- a/lib/preservation/client/versioned_api_service.rb
+++ b/lib/preservation/client/versioned_api_service.rb
@@ -34,7 +34,7 @@ module Preservation
       rescue Faraday::ResourceNotFound => e
         errmsg = "HTTP GET to #{connection.url_prefix}#{req_url} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::NotFoundError, errmsg
-      rescue Faraday::ParsingError, Faraday::RetriableResponse => e
+      rescue Faraday::Error => e
         errmsg = "HTTP GET to #{connection.url_prefix}#{req_url} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::UnexpectedResponseError, errmsg
       end
@@ -60,15 +60,13 @@ module Preservation
         return resp.body if resp.success?
 
         errmsg = ResponseErrorFormatter.format(response: resp, client_method_name: caller_locations.first.label)
-        if resp.status == 404
-          raise Preservation::Client::NotFoundError, errmsg
-        else
-          raise Preservation::Client::UnexpectedResponseError, errmsg
-        end
+        raise Preservation::Client::NotFoundError, errmsg if resp.status == 404
+
+        raise Preservation::Client::UnexpectedResponseError, errmsg
       rescue Faraday::ResourceNotFound => e
         errmsg = "HTTP #{method.to_s.upcase} to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::NotFoundError, errmsg
-      rescue Faraday::ParsingError, Faraday::RetriableResponse => e
+      rescue Faraday::Error => e
         errmsg = "HTTP #{method.to_s.upcase} to #{connection.url_prefix}#{path} failed with #{e.class}: #{e.message}"
         raise Preservation::Client::UnexpectedResponseError, errmsg
       end

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -376,13 +376,13 @@ RSpec.describe Preservation::Client::Objects do
         allow(subject).to receive(:get).with(file_api_path, file_api_params).and_raise(Preservation::Client::UnexpectedResponseError, err_msg)
       end
 
-      it 'if 404 status, return new Moab::SignatureCatalog for druid' do
-        prescat_err_msg = "Preservation::Client.signature_catalog for #{file_druid} got 404 File Not Found (404) from Preservation ..."
-        allow(subject).to receive(:get).with(file_api_path, file_api_params).and_raise(Preservation::Client::UnexpectedResponseError, prescat_err_msg)
-        expect(subject.signature_catalog(file_druid).to_xml).to eq Moab::SignatureCatalog.new(digital_object_id: file_druid, version_id: 0).to_xml
+      it 'if 404 status, raise NotFoundError' do
+        errmsg_not_found = "Preservation::Client.signature_catalog for #{file_druid} got 404 File Not Found (404) from Preservation ..."
+        allow(subject).to receive(:get).with(file_api_path, file_api_params).and_raise(Preservation::Client::NotFoundError, errmsg_not_found)
+        expect { subject.signature_catalog(file_druid) }.to raise_error(Preservation::Client::NotFoundError, errmsg_not_found)
       end
 
-      it 'if not 404 status, raises an error' do
+      it 'if not 404 status, raise UnexpectedResponseError' do
         allow(subject).to receive(:get).with(file_api_path, file_api_params).and_raise(Preservation::Client::UnexpectedResponseError, err_msg)
         expect { subject.signature_catalog(file_druid) }.to raise_error(Preservation::Client::UnexpectedResponseError, err_msg)
       end

--- a/spec/preservation/client/versioned_api_service_spec.rb
+++ b/spec/preservation/client/versioned_api_service_spec.rb
@@ -108,7 +108,14 @@ RSpec.describe Preservation::Client::VersionedApiService do
       end
     end
 
-    context 'when response status NOT success' do
+    context 'when response status 404' do
+      it 'raises Preservation::Client::NotFound with message from ResponseErrorFormatter' do
+        stub_request(:get, "#{prez_api_url}/#{api_version}/#{path}?#{params_as_args}").to_return(status: 404)
+        expect { subject.send(:get, path, params) }.to raise_error(Preservation::Client::NotFoundError, /got 404/)
+      end
+    end
+
+    context 'when response status NOT success or 404' do
       it 'raises Preservation::Client::UnexpectedResponseError with message from ResponseErrorFormatter' do
         stub_request(:get, "#{prez_api_url}/#{api_version}/#{path}?#{params_as_args}").to_return(status: 500)
         expect { subject.send(:get, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, /got 500/)
@@ -165,7 +172,14 @@ RSpec.describe Preservation::Client::VersionedApiService do
       end
     end
 
-    context 'when response status NOT success' do
+    context 'when response status 404' do
+      it 'raises Preservation::Client::NotFound with message from ResponseErrorFormatter' do
+        stub_request(:post, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 404)
+        expect { subject.send(:post, path, params) }.to raise_error(Preservation::Client::NotFoundError, /got 404/)
+      end
+    end
+
+    context 'when response status NOT success or 404' do
       it 'raises Preservation::Client::UnexpectedResponseError with message from ResponseErrorFormatter' do
         stub_request(:post, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 500)
         expect { subject.send(:post, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, /got 500/)


### PR DESCRIPTION
(you may f

## Why was this change made?

1.  Client should throw its own NotFoundError when 404 is returned from API call to preservation-catalog.  (issue #16)
2.  `signature_catalog` method should throw NotFoundError when there is no such file;  it is up to the caller to handle this as caller sees fit.  (part of sunsetting sdr-services-app;  the call to get signature_catalog is the last remaining call to be deprecated)
3.  more streamlined code for handling errors in API calls
4.  reduce duplication in code for making API calls.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes, README