### PR TITLE
Added documentation to client.rb towords removing rubocop exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
-    - 'lib/preservation/client.rb'
+
 
 Style/WordArray:
   Enabled: false

--- a/lib/preservation/client.rb
+++ b/lib/preservation/client.rb
@@ -7,6 +7,7 @@ require 'faraday'
 require 'singleton'
 require 'zeitwerk'
 
+# Provides version exception to camels-case conversion
 class PreservationClientInflector < Zeitwerk::Inflector
   def camelize(basename, _abspath)
     case basename
@@ -24,6 +25,7 @@ loader.push_dir(File.absolute_path("#{__FILE__}/../.."))
 loader.setup
 
 module Preservation
+  # REST API client wrapper for PreservationCatalog with error handling
   class Client
     class Error < StandardError; end
 


### PR DESCRIPTION
## Why was this change made?
Starting documentation that was an exception for `rubocop`.  

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a