### PR TITLE
set default api version to 'v1'

### DIFF
--- a/lib/preservation/client/versioned_api_service.rb
+++ b/lib/preservation/client/versioned_api_service.rb
@@ -2,9 +2,11 @@
 
 module Preservation
   class Client
+    DEFAULT_API_VERSION = 'v1'
+
     # @abstract API calls to a versioned endpoint
     class VersionedApiService
-      def initialize(connection:, api_version:)
+      def initialize(connection:, api_version: DEFAULT_API_VERSION)
         @connection = connection
         @api_version = api_version
       end


### PR DESCRIPTION
## Why was this change made?

https://github.com/sul-dlss/preservation_catalog/pull/1266 make prescat routes be v1;  this defaults this client gem to use 'v1' as version.

Longer term fix might be to set this in shared_configs ... but only if we were maintaining more than one version of the API at a time.

## Was the documentation (README, API, wiki, consul, etc.) updated?

n/a