### PR TITLE
Remove unused Faraday::ParsingError

### DIFF
--- a/spec/preservation/client/versioned_api_service_spec.rb
+++ b/spec/preservation/client/versioned_api_service_spec.rb
@@ -64,14 +64,6 @@ RSpec.describe Preservation::Client::VersionedApiService do
       end
     end
 
-    context 'when Faraday::ParsingError raised' do
-      it 'raises Preservation::Client::UnexpectedResponseError' do
-        allow(conn).to receive(:get).and_raise(Faraday::ParsingError, faraday_err_msg)
-        exp_err_msg = "HTTP GET to #{prez_api_url}/#{api_version}/#{path} failed with #{Faraday::ParsingError}: #{faraday_err_msg}"
-        expect { subject.send(:get_json, path, druid) }.to raise_error(Preservation::Client::UnexpectedResponseError, exp_err_msg)
-      end
-    end
-
     context 'when Faraday::RetriableResponse raised' do
       it 'raises Preservation::Client::UnexpectedResponseError' do
         allow(conn).to receive(:get).and_raise(Faraday::RetriableResponse, faraday_err_msg)
@@ -130,14 +122,6 @@ RSpec.describe Preservation::Client::VersionedApiService do
       end
     end
 
-    context 'when Faraday::ParsingError raised' do
-      it 'raises Preservation::Client::UnexpectedResponseError' do
-        allow(conn).to receive(:get).and_raise(Faraday::ParsingError, faraday_err_msg)
-        exp_err_msg = "HTTP GET to #{prez_api_url}/#{path} failed with #{Faraday::ParsingError}: #{faraday_err_msg}"
-        expect { subject.send(:get, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, exp_err_msg)
-      end
-    end
-
     context 'when Faraday::RetriableResponse raised' do
       it 'raises Preservation::Client::UnexpectedResponseError' do
         allow(conn).to receive(:get).and_raise(Faraday::RetriableResponse, faraday_err_msg)
@@ -191,14 +175,6 @@ RSpec.describe Preservation::Client::VersionedApiService do
         allow(conn).to receive(:post).and_raise(Faraday::ResourceNotFound, faraday_err_msg)
         exp_err_msg = "HTTP POST to #{prez_api_url}/#{path} failed with #{Faraday::ResourceNotFound}: #{faraday_err_msg}"
         expect { subject.send(:post, path, params) }.to raise_error(Preservation::Client::NotFoundError, exp_err_msg)
-      end
-    end
-
-    context 'when Faraday::ParsingError raised' do
-      it 'raises Preservation::Client::UnexpectedResponseError' do
-        allow(conn).to receive(:post).and_raise(Faraday::ParsingError, faraday_err_msg)
-        exp_err_msg = "HTTP POST to #{prez_api_url}/#{path} failed with #{Faraday::ParsingError}: #{faraday_err_msg}"
-        expect { subject.send(:post, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, exp_err_msg)
       end
     end
 


### PR DESCRIPTION


## Why was this change made?
We don't have faraday-middleware in the stack so Faraday::ParsingError isn't ever used.
See https://github.com/lostisland/faraday/issues/818

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a