### PR TITLE
Error middleware

### DIFF
--- a/lib/preservation/client.rb
+++ b/lib/preservation/client.rb
@@ -73,6 +73,7 @@ module Preservation
       @connection ||= Faraday.new(url) do |builder|
         builder.use ErrorFaradayMiddleware
         builder.use Faraday::Request::UrlEncoded
+        builder.use Faraday::Response::RaiseError
 
         builder.adapter Faraday.default_adapter
         builder.headers[:user_agent] = user_agent


### PR DESCRIPTION
## Why was this change made?

We were handling Faraday::Error exceptions, except without the middleware, we were never raising those exceptions.


## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a


## Depends on
- [x] #24 
- [x] #23 