### PR TITLE
Add a method for sending an update to the catalog endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Note that the preservation service is behind a firewall.
 
 - `client.objects.shelve_content_diff(druid: 'oo000oo0000', content_metadata: '<contentMetadata>...</contentMetadata>')` - returns Moab::FileGroupDifference containing differences between passed content metadata and latest version for subset 'shelve'
 
+### Alert the catalog that an object has been changed and needs to be updated
+
+- `client.update(druid: 'oo000oo0000', version: 3, size: 2342, storage_location: 'some/storage/location')` - returns true if it worked
 ## Development
 
 After checking out the repo, run `bundle` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/preservation/client.rb
+++ b/lib/preservation/client.rb
@@ -47,6 +47,11 @@ module Preservation
       @objects ||= Objects.new(connection: connection, api_version: DEFAULT_API_VERSION)
     end
 
+    # @return [Preservation::Client::Catalog] an instance of the `Client::Catalog` class
+    def catalog
+      @catalog ||= Catalog.new(connection: connection, api_version: DEFAULT_API_VERSION)
+    end
+
     class << self
       # @param [String] url
       def configure(url:)
@@ -58,10 +63,11 @@ module Preservation
         self
       end
 
-      delegate :objects, to: :instance
+      delegate :objects, :update, to: :instance
     end
 
     attr_writer :url, :connection
+    delegate :update, to: :catalog
 
     private
 
@@ -73,8 +79,7 @@ module Preservation
       @connection ||= Faraday.new(url) do |builder|
         builder.use ErrorFaradayMiddleware
         builder.use Faraday::Request::UrlEncoded
-        builder.use Faraday::Response::RaiseError
-
+        builder.use Faraday::Response::RaiseError # raise exceptions on 40x, 50x responses
         builder.adapter Faraday.default_adapter
         builder.headers[:user_agent] = user_agent
       end

--- a/lib/preservation/client/catalog.rb
+++ b/lib/preservation/client/catalog.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Preservation
+  class Client
+    # API calls that are about the catalog
+    class Catalog < VersionedApiService
+      # @param [String] druid the object identifierx
+      # @param [Integer] version the version of the object
+      # @param [Integer] size the size of the object
+      # @param [String] storage_location the location of storage
+      def update(druid:, version:, size:, storage_location:)
+        http_args = {
+          druid: druid,
+          incoming_version: version,
+          incoming_size: size,
+          storage_location: storage_location,
+          checksums_validated: true
+        }
+
+        request(druid: druid, version: version, http_args: http_args)
+      end
+
+      private
+
+      def request(druid:, version:, http_args:)
+        result = if version == 1
+                   connection.post "/#{api_version}/catalog", http_args
+                 else
+                   connection.patch "/#{api_version}/catalog/#{druid}", http_args
+                 end
+        unless result.success?
+          raise UnexpectedResponseError, "response was not successful. Received status #{result.status}"
+        end
+
+        true
+      rescue Faraday::ClientError => e
+        raise UnexpectedResponseError, e
+      end
+    end
+  end
+end

--- a/spec/preservation/client/catalog_spec.rb
+++ b/spec/preservation/client/catalog_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Preservation::Client::Catalog do
+  let(:prez_api_url) { 'https://prezcat.example.com' }
+
+  before do
+    Preservation::Client.configure(url: prez_api_url)
+  end
+
+  let(:conn) { Preservation::Client.instance.send(:connection) }
+  subject(:instance) { described_class.new(connection: conn) }
+  let(:err_msg) { 'Mistakes were made.' }
+
+  describe '#update' do
+    let(:path) { "objects/#{druid}.json" }
+    let(:druid) { 'bj102hs9687' }
+    subject(:update) do
+      instance.update(druid: druid,
+                      version: version,
+                      size: 2342,
+                      storage_location: 'some/storage/location/from/endpoint/table')
+    end
+
+    let(:expected_body) do
+      {
+        'checksums_validated' => 'true', 'druid' => 'bj102hs9687',
+        'incoming_size' => '2342', 'incoming_version' => version,
+        'storage_location' => 'some/storage/location/from/endpoint/table'
+      }
+    end
+
+    context 'when the request is successful' do
+      context 'when the object is new (version == 1)' do
+        let(:version) { 1 }
+
+        context 'when API request succeeds' do
+          before do
+            stub_request(:post, 'https://prezcat.example.com/v1/catalog')
+              .with(body: expected_body)
+              .to_return(status: 200, body: '', headers: {})
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context 'when API request fails' do
+          before do
+            stub_request(:post, 'https://prezcat.example.com/v1/catalog')
+              .with(body: expected_body)
+              .to_return(status: 500, body: '', headers: {})
+          end
+
+          it 'raises an error' do
+            expect { update }.to raise_error(Preservation::Client::UnexpectedResponseError,
+                                             'the server responded with status 500')
+          end
+        end
+
+        context 'when API redirects' do
+          before do
+            stub_request(:post, 'https://prezcat.example.com/v1/catalog')
+              .with(body: expected_body)
+              .to_return(status: 301, body: '', headers: {})
+          end
+
+          it 'raises an error' do
+            expect { update }.to raise_error(Preservation::Client::UnexpectedResponseError,
+                                             'response was not successful. Received status 301')
+          end
+        end
+      end
+
+      context 'when the object exists in the catalog (version > 1)' do
+        let(:version) { 2 }
+        context 'when API request succeeds' do
+          before do
+            stub_request(:patch, 'https://prezcat.example.com/v1/catalog/bj102hs9687')
+              .with(body: expected_body)
+              .to_return(status: 200, body: '', headers: {})
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context 'when API request fails' do
+          before do
+            stub_request(:patch, 'https://prezcat.example.com/v1/catalog/bj102hs9687')
+              .with(body: expected_body)
+              .to_return(status: 500, body: '', headers: {})
+          end
+
+          it 'raises an error' do
+            expect { update }.to raise_error(Preservation::Client::UnexpectedResponseError, 'the server responded with status 500')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

So that the preservation_robots can use the client to access the  update API

## Was the documentation (README, API, wiki, consul, etc.) updated?
yes.