### PR TITLE
Allow faraday 1.0

### DIFF
--- a/lib/preservation/client/catalog.rb
+++ b/lib/preservation/client/catalog.rb
@@ -33,7 +33,7 @@ module Preservation
         end
 
         true
-      rescue Faraday::ClientError => e
+      rescue Faraday::Error => e
         raise UnexpectedResponseError, e
       end
     end

--- a/preservation-client.gemspec
+++ b/preservation-client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 7'
-  spec.add_dependency 'faraday', '~> 0.15'
+  spec.add_dependency 'faraday', '>= 0.15', '< 2.0'
   spec.add_dependency 'moab-versioning', '~> 4.3'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 


### PR DESCRIPTION
## Why was this change made?

So that one can use faraday  1.0 with this gem

## Was the documentation (README, API, wiki, consul, etc.) updated?
n/a