### PR TITLE
require that client specify auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ end
 private
 
 def client
-  @client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url)
+  @client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
 end
 ```
 
@@ -47,7 +47,7 @@ OR
 require 'preservation/client'
 
 def initialize
-  Preservation::Client.configure(url: Settings.preservation_catalog.url)
+  Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
 end
 
 def do_the_thing
@@ -55,7 +55,9 @@ def do_the_thing
 end
 ```
 
-Note that the client may **not** be used without first having been configured, and the `url` keyword is **required**.
+Note that the client may **not** be used without first having been configured, and both the `url` and `token` keywords are **required**.
+
+See https://github.com/sul-dlss/preservation_catalog#api for info on obtaining a valid API token.
 
 Note that the preservation service is behind a firewall.
 

--- a/lib/preservation/client/version.rb
+++ b/lib/preservation/client/version.rb
@@ -2,6 +2,6 @@
 
 module Preservation
   class Client
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
   end
 end

--- a/spec/preservation/client/catalog_spec.rb
+++ b/spec/preservation/client/catalog_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe Preservation::Client::Catalog do
   let(:prez_api_url) { 'https://prezcat.example.com' }
+  let(:auth_token) { 'my_secret_jwt_value' }
 
   before do
-    Preservation::Client.configure(url: prez_api_url)
+    Preservation::Client.configure(url: prez_api_url, token: auth_token)
   end
 
   let(:conn) { Preservation::Client.instance.send(:connection) }

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe Preservation::Client::Objects do
   let(:prez_api_url) { 'https://prezcat.example.com' }
+  let(:auth_token) { 'my_secret_jwt_value' }
 
   before do
-    Preservation::Client.configure(url: prez_api_url)
+    Preservation::Client.configure(url: prez_api_url, token: auth_token)
   end
 
   let(:conn) { Preservation::Client.instance.send(:connection) }

--- a/spec/preservation/client/versioned_api_service_spec.rb
+++ b/spec/preservation/client/versioned_api_service_spec.rb
@@ -2,11 +2,12 @@
 
 RSpec.describe Preservation::Client::VersionedApiService do
   let(:prez_api_url) { 'https://prezcat.example.com' }
+  let(:auth_token) { 'my_secret_jwt_value' }
   let(:druid) { 'oo000oo0000' }
   let(:faraday_err_msg) { 'faraday is sad' }
 
   before do
-    Preservation::Client.configure(url: prez_api_url)
+    Preservation::Client.configure(url: prez_api_url, token: auth_token)
   end
 
   let(:conn) { Preservation::Client.instance.send(:connection) }


### PR DESCRIPTION
## Why was this change made?

We'll be requiring that all Preservation Catalog API clients send a valid JWT for access.  This change adds support for token auth to the client gem.

## Was the documentation (README, API, wiki, consul, etc.) updated?

yup

connects with https://github.com/sul-dlss/preservation_catalog/issues/1298 and https://github.com/sul-dlss/preservation_catalog/pull/1306