### PR TITLE
have travis use bundler 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - "RAILS_VERSION=5.2.3"
   - "RAILS_VERSION=6.0.0"
 
-before_install: gem install bundler -v 2.0.2
+before_install: gem install bundler -v 2.1.2
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
## Why was this change made?

- because 2.1.2 is the default bundler for ruby 2.6.4 when updating rubygems
- because I had this change on my laptop anyway
- because i'm a nerd
- because i have OCD

## Was the documentation (README, API, wiki, consul, etc.) updated?

n/a