### PR TITLE
change 'auth_token' key to just 'token'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ end
 private
 
 def client
-  @client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
+  @client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
 end
 ```
 
@@ -47,7 +47,7 @@ OR
 require 'preservation/client'
 
 def initialize
-  Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
+  Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
 end
 
 def do_the_thing


### PR DESCRIPTION
@jmartin-sul  - easy merge into your branch for draft PR.

NOTE:  the specs were already using "token" as the key, and only had "auth_token" as the variable value

## Why was this change made?

- @jmartin-sul and I discussed this and settled on "token" as the key
- to match our other auth token usage (e.g. dor-services-app)
- to match our shared_configs (https://github.com/sul-dlss/shared_configs/pull/1171 - 1178)

## Was the documentation (README, API, wiki, consul, etc.) updated?

n/a