### PR TITLE
Update client_spec regex to allow for variable error message based on…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 rvm:
   - 2.5.3
   - 2.6.4
+  - 2.7.1
 
 env:
   - "RAILS_VERSION=5.2.3"

--- a/spec/preservation/client_spec.rb
+++ b/spec/preservation/client_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe Preservation::Client do
       expect(client.instance.send(:token)).to eq auth_token
     end
     it 'raises error if no url or token provided' do
-      expect { described_class.configure }.to raise_error(ArgumentError, /missing keywords: (:?)url, (:?)token/) # /(missing keywords:) url, token/)
+      expect { described_class.configure }.to raise_error(ArgumentError, /missing keywords: :?url, :?token/)
     end
     it 'raises error if no url provided' do
-      expect { described_class.configure(token: auth_token) }.to raise_error(ArgumentError, /missing keyword: (:?)url/)
+      expect { described_class.configure(token: auth_token) }.to raise_error(ArgumentError, /missing keyword: :?url/)
     end
     it 'raises error if no token provided' do
-      expect { described_class.configure(url: prez_url) }.to raise_error(ArgumentError, /missing keyword: (:?)token/)
+      expect { described_class.configure(url: prez_url) }.to raise_error(ArgumentError, /missing keyword: :?token/)
     end
     it 'connection is populated' do
       connection = client.instance.send(:connection)

--- a/spec/preservation/client_spec.rb
+++ b/spec/preservation/client_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe Preservation::Client do
       expect(client.instance.send(:token)).to eq auth_token
     end
     it 'raises error if no url or token provided' do
-      expect { described_class.configure }.to raise_error(ArgumentError, /missing keywords: url, token/)
+      expect { described_class.configure }.to raise_error(ArgumentError, /missing keywords: (:?)url, (:?)token/) # /(missing keywords:) url, token/)
     end
     it 'raises error if no url provided' do
-      expect { described_class.configure(token: auth_token) }.to raise_error(ArgumentError, /missing keyword: url/)
+      expect { described_class.configure(token: auth_token) }.to raise_error(ArgumentError, /missing keyword: (:?)url/)
     end
     it 'raises error if no token provided' do
-      expect { described_class.configure(url: prez_url) }.to raise_error(ArgumentError, /missing keyword: token/)
+      expect { described_class.configure(url: prez_url) }.to raise_error(ArgumentError, /missing keyword: (:?)token/)
     end
     it 'connection is populated' do
       connection = client.instance.send(:connection)


### PR DESCRIPTION
… ruby version

## Why was this change made?

When using ruby 2.7.1 locally, I found that this error message returned in the client_spec was slightly different, referring to the variables as symbols instead of strings. This updated regex should allow test test to run against 2.5, 2.6 and 2.7


## How was this change tested?

Unit


## Which documentation and/or configurations were updated?

N/A


