### PR TITLE
Add storage location query to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Note that the preservation service is behind a firewall.
     - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8')` - returns contents of identityMetadata.xml in version 8 of Moab object
 - `client.objects.signature_catalog('oo000oo0000')` - returns latest Moab::SignatureCatalog from Moab
 
+### Retrieve the primary moab storage location
+
+- `client.objects.primary_moab_location(druid: 'ooo000oo0000')` - returns the path to the storage location for the primary moab
+
 ### Get difference information between passed contentMetadata.xml and files in the Moab
 
 - `client.objects.content_inventory_diff(druid: 'oo000oo0000', content_metadata: '<contentMetadata>...</contentMetadata>')` - returns Moab::FileInventoryDifference containing differences between passed content metadata and latest version for subset 'all'

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -71,6 +71,13 @@ module Preservation
         file(druid, 'metadata', filepath, version)
       end
 
+      # retrieve the storage location for the primary moab of the given druid
+      # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
+      # @return [String] the storage location of the primary moab for the gviven druid
+      def primary_moab_location(druid:)
+        get("objects/#{druid}/primary_moab_location", {}, on_data: nil)
+      end
+
       # convenience method for retrieving latest Moab::SignatureCatalog from a Moab object,
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
       # @return [Moab::SignatureCatalog] the manifest of all files previously ingested

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -74,6 +74,7 @@ module Preservation
       # retrieve the storage location for the primary moab of the given druid
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
       # @return [String] the storage location of the primary moab for the given druid
+      # @raise [Preservation::Client::NotFoundError] when druid is not found
       def primary_moab_location(druid:)
         get("objects/#{druid}/primary_moab_location", {}, on_data: nil)
       end

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -73,7 +73,7 @@ module Preservation
 
       # retrieve the storage location for the primary moab of the given druid
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
-      # @return [String] the storage location of the primary moab for the gviven druid
+      # @return [String] the storage location of the primary moab for the given druid
       def primary_moab_location(druid:)
         get("objects/#{druid}/primary_moab_location", {}, on_data: nil)
       end

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -323,6 +323,32 @@ RSpec.describe Preservation::Client::Objects do
     end
   end
 
+  describe '#primary_moab_location' do
+    let(:druid) { 'oo000oo0000' }
+
+    context 'when API request succeeds' do
+      let(:storage_location) { 'a/generic/storage_root/sdr2objects' }
+
+      before do
+        allow(subject).to receive(:get).and_return(storage_location)
+      end
+
+      it 'returns the path to the primary moab storage location' do
+        expect(subject.primary_moab_location(druid: druid)).to eq storage_location
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        allow(subject).to receive(:get).and_raise(Preservation::Client::NotFoundError)
+      end
+
+      it 'raises an error' do
+        expect { subject.primary_moab_location(druid: druid) }.to raise_error(Preservation::Client::NotFoundError)
+      end
+    end
+  end
+
   describe '#signature_catalog' do
     let(:file_api_params) do
       {


### PR DESCRIPTION
## Why was this change made?

Exposes the new REST endpoint for the primary moab storage location through the preservation client as part of https://github.com/sul-dlss/preservation_robots/issues/239

## How was this change tested?

unit tests


## Which documentation and/or configurations were updated?

README


