### PR TITLE
add a new method to call the validate_moab endpoint

### DIFF
--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -71,6 +71,15 @@ module Preservation
         file(druid, 'metadata', filepath, version)
       end
 
+      # calls the endpoint to queue a ValidateMoab job for a specific druid
+      # typically called by a preservationIngestWF robot
+      # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
+      # @return [String] "ok" when job queued
+      # @raise [Preservation::Client::NotFoundError] when druid is not found
+      def validate_moab(druid:)
+        get("objects/#{druid}/validate_moab", {}, on_data: nil)
+      end
+
       # retrieve the storage location for the primary moab of the given druid
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
       # @return [String] the storage location of the primary moab for the given druid

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -323,6 +323,34 @@ RSpec.describe Preservation::Client::Objects do
     end
   end
 
+  describe '#validate_moab' do
+    subject(:request) { client.validate_moab(druid: druid) }
+
+    let(:druid) { 'oo000oo0000' }
+
+    context 'when API request succeeds' do
+      before do
+        stub_request(:get, "https://prezcat.example.com/objects/#{druid}/validate_moab")
+          .to_return(status: 200, body: 'ok', headers: {})
+      end
+
+      it 'returns ok' do
+        expect(request).to eq 'ok'
+      end
+    end
+
+    context 'when API request fails with object not found' do
+      before do
+        stub_request(:get, "https://prezcat.example.com/objects/#{druid}/validate_moab")
+          .to_return(status: 404, headers: {})
+      end
+
+      it 'raises an error' do
+        expect { request }.to raise_error(Preservation::Client::NotFoundError)
+      end
+    end
+  end
+
   describe '#primary_moab_location' do
     subject(:request) { client.primary_moab_location(druid: druid) }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #46 - adds a new method to call the `validate_moab` endpoint, which will be used by sul-dlss/preservation_robots#315

## How was this change tested?

Added a new test


## Which documentation and/or configurations were updated?



