### PR TITLE
bump sul-dlss circleci orb to 3.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@2.0.0
+  ruby-rails: sul-dlss/ruby-rails@3.1.2
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Let's make sure we run ALL the specs.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


