### PR TITLE
update required_ruby_version to 3.0

### DIFF
--- a/preservation-client.gemspec
+++ b/preservation-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7' # 3.0 except for dor-services-app
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
   spec.add_dependency 'faraday', '~> 2.0'


### PR DESCRIPTION
## Why was this change made? 🤔

we're now at least 3.0 everywhere

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


