### PR TITLE
remove primary_moab_location as it is no longer needed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       json
       nokogiri
       nokogiri-happymapper
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     nokogiri-happymapper (0.9.0)
@@ -107,6 +109,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ Note that the preservation service is behind a firewall.
     - `client.objects.metadata(druid: 'oo000oo0000', filepath: 'identityMetadata.xml', version: '8')` - returns contents of identityMetadata.xml in version 8 of Moab object
 - `client.objects.signature_catalog('oo000oo0000')` - returns latest Moab::SignatureCatalog from Moab
 
-### Retrieve the primary moab storage location
-
-- `client.objects.primary_moab_location(druid: 'ooo000oo0000')` - returns the path to the storage location for the primary moab
-
 ### Validate the Moab
 
 - `client.objects.validate_moab(druid: 'ooo000oo0000')` - validates that the Moab object, used by preservationWF to ensure we have a valid Moab before replicating to various preservation endpoints
@@ -99,6 +95,7 @@ Note that the preservation service is behind a firewall.
 ### Get difference information between passed contentMetadata.xml and files in the Moab
 
 - `client.objects.content_inventory_diff(druid: 'oo000oo0000', content_metadata: '<contentMetadata>...</contentMetadata>')` - returns Moab::FileInventoryDifference containing differences between passed content metadata and latest version for subset 'all'
+
   - you may specify the subset (all|shelve|preserve|publish) and/or the version:
     - `client.objects.content_inventory_diff(druid: 'oo000oo0000', subset: 'publish', version: '1', content_metadata: '<contentMetadata>...</contentMetadata>')`
 
@@ -107,6 +104,7 @@ Note that the preservation service is behind a firewall.
 ### Alert the catalog that an object has been changed and needs to be updated
 
 - `client.update(druid: 'oo000oo0000', version: 3, size: 2342, storage_location: 'some/storage/location')` - returns true if it worked
+
 ## Development
 
 After checking out the repo, run `bundle` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -80,15 +80,6 @@ module Preservation
         get("objects/#{druid}/validate_moab", {}, on_data: nil)
       end
 
-      # retrieve the storage location for the primary moab of the given druid
-      # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
-      # @return [String] the storage location of the primary moab for the given druid
-      # @raise [Preservation::Client::NotFoundError] when druid is not found
-      # @raise [Preservation::Client::LockedError] when druid is in locked state (not available for versioning)
-      def primary_moab_location(druid:)
-        get("objects/#{druid}/primary_moab_location", {}, on_data: nil)
-      end
-
       # convenience method for retrieving latest Moab::SignatureCatalog from a Moab object,
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' OR 'ab123cd4567'
       # @return [Moab::SignatureCatalog] the manifest of all files previously ingested

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -350,36 +350,6 @@ RSpec.describe Preservation::Client::Objects do
     end
   end
 
-  describe '#primary_moab_location' do
-    subject(:request) { client.primary_moab_location(druid: druid) }
-
-    let(:druid) { 'oo000oo0000' }
-    let(:locked_message) { "Cannot retrieve primary moab location because versioning is locked for the preserved object with id #{druid}" }
-    let(:storage_location) { 'a/generic/storage_root/sdr2objects' }
-
-    context 'when API request succeeds' do
-      before do
-        stub_request(:get, "https://prezcat.example.com/objects/#{druid}/primary_moab_location")
-          .to_return(status: 200, body: storage_location, headers: {})
-      end
-
-      it 'returns the path to the primary moab storage location' do
-        expect(request).to eq storage_location
-      end
-    end
-
-    context 'when API request fails' do
-      before do
-        stub_request(:get, "https://prezcat.example.com/objects/#{druid}/primary_moab_location")
-          .to_return(status: 423, body: locked_message, headers: {})
-      end
-
-      it 'raises an error' do
-        expect { request }.to raise_error(Preservation::Client::LockedError)
-      end
-    end
-  end
-
   describe '#signature_catalog' do
     let(:file_api_params) do
       {


### PR DESCRIPTION
## Why was this change made? 🤔

We are removing code for multiple moab instances, as it is no longer useful.    

Besides epic ticket sul-dlss/preservation_catalog/issues/1892, I confirmed with a github search that this was only used by preservation_robots.

Fixes #56

I will cut a new release of this gem after this PR is merged.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


