### PR TITLE
Allow moab-versioning 6.x releases to be used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     preservation-client (5.0.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
-      moab-versioning (~> 5.0)
+      moab-versioning (>= 5.0.0, < 7)
       zeitwerk (~> 2.1)
 
 GEM
@@ -128,4 +128,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.17
+   2.4.4

--- a/preservation-client.gemspec
+++ b/preservation-client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
   spec.add_dependency 'faraday', '~> 2.0'
-  spec.add_dependency 'moab-versioning', '~> 5.0'
+  spec.add_dependency 'moab-versioning', '>= 5.0.0', '< 7'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/moab-versioning#262

The work in moab-versioning 6.0.0 does not affect the data structures preservation-client references, so allowing 5.x and 6.x should be safe.


## How was this change tested? 🤨

CI
