### PR TITLE
increase read_timeout

### DIFF
--- a/lib/preservation/client.rb
+++ b/lib/preservation/client.rb
@@ -77,7 +77,7 @@ module Preservation
     end
 
     def connection
-      @connection ||= Faraday.new(url) do |builder|
+      @connection ||= Faraday.new(url, request: { read_timeout: 300 }) do |builder|
         builder.use ErrorFaradayMiddleware
         builder.use Faraday::Request::UrlEncoded
         builder.use Faraday::Response::RaiseError # raise exceptions on 40x, 50x responses


### PR DESCRIPTION
## Why was this change made? 🤔

To deal with HB errors being triggered by preservation catalog timeouts (triggered when calling shelving from dor-services-app)

https://app.honeybadger.io/projects/50568/faults/86326783/01GQG066NHXAHRZXXGXJC5ZP6J

## How was this change tested? 🤨

With a branch of DSA on stage, and running some longer running objects through to see that they now complete


