### PR TITLE
explicitly handle 409 conflict errors on updates, shore up related tests

### DIFF
--- a/lib/preservation/client.rb
+++ b/lib/preservation/client.rb
@@ -23,6 +23,9 @@ module Preservation
     # Error raised when server returns 423 Locked
     class LockedError < Error; end
 
+    # Error raised when server returns 409 Conflict
+    class ConflictError < Error; end
+
     # Error raised when server returns an unexpected response
     # e.g., 4xx or 5xx status not otherwise handled
     class UnexpectedResponseError < Error; end

--- a/lib/preservation/client/versioned_api_service.rb
+++ b/lib/preservation/client/versioned_api_service.rb
@@ -95,8 +95,19 @@ module Preservation
       rescue Faraday::Error => e
         errmsg = "Preservation::Client.#{caller_locations.first.label} " \
                  "got #{e.response[:status]} from Preservation at #{req_url}: #{e.response[:body]}"
-        exception_class = e.response[:status] == 423 ? LockedError : UnexpectedResponseError
-        raise exception_class, errmsg
+        raise http_exception_class(e.response[:status]), errmsg
+      end
+
+      # @param status_code [Integer] the HTTP status code to translate to an exception class
+      def http_exception_class(status_code)
+        case status_code
+        when 423
+          LockedError
+        when 409
+          ConflictError
+        else
+          UnexpectedResponseError
+        end
       end
     end
   end

--- a/spec/preservation/client/versioned_api_service_spec.rb
+++ b/spec/preservation/client/versioned_api_service_spec.rb
@@ -201,10 +201,29 @@ RSpec.describe Preservation::Client::VersionedApiService do
           end
         end
 
-        context 'when response status is neither 200 or 404' do
-          it 'raises Preservation::Client::UnexpectedResponseError with message from ResponseErrorFormatter' do
+        context 'when response is 409' do
+          it 'raises Preservation::Client::ConflictError with message from ResponseErrorFormatter' do
+            stub_request(method, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 409)
+            expect { service.send(method, path, params) }.to raise_error(Preservation::Client::ConflictError, /got 409/)
+          end
+        end
+
+        context 'when response is 423' do
+          it 'raises Preservation::Client::LockedError with message from ResponseErrorFormatter' do
+            stub_request(method, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 423)
+            expect { service.send(method, path, params) }.to raise_error(Preservation::Client::LockedError, /got 423/)
+          end
+        end
+
+        context 'when response status is other than a specifically handled error' do
+          it 'raises Preservation::Client::UnexpectedResponseError with message from ResponseErrorFormatter for a 500 error' do
             stub_request(method, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 500)
             expect { service.send(method, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, /got 500/)
+          end
+
+          it 'raises Preservation::Client::UnexpectedResponseError with message from ResponseErrorFormatter for any other unexpected error' do
+            stub_request(method, "#{prez_api_url}/#{api_version}/#{path}").to_return(status: 418)
+            expect { service.send(method, path, params) }.to raise_error(Preservation::Client::UnexpectedResponseError, /got 418/)
           end
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔

pres cat sometimes sends back a 409 response.  this can happen if, e.g., the moab_to_catalog audit discovers a moab on disk after a network issue or other problem kept pres robots from successfully notifying pres cat about the new object version.

specifically handling this error code will allow pres robots to trap this situation more gracefully.

see e.g. https://app.honeybadger.io/projects/55564/faults/93065492

also, small enhancements to testing of this area of the code in general.

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


