### PR TITLE
Adds status checking when streaming content.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       nokogiri-happymapper
     net-http (0.4.1)
       uri
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
@@ -137,6 +139,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/spec/preservation/client/versioned_api_service_spec.rb
+++ b/spec/preservation/client/versioned_api_service_spec.rb
@@ -180,9 +180,19 @@ RSpec.describe Preservation::Client::VersionedApiService do
       let(:buffer) { [] }
       let(:resp_body) { "I'm a little teacup" }
 
-      it 'streams' do
-        get
-        expect(buffer).to eq ["I'm a little teacup"]
+      context 'when it is successful' do
+        it 'streams' do
+          get
+          expect(buffer).to eq ["I'm a little teacup"]
+        end
+      end
+
+      context 'when an error response' do
+        let(:status) { 404 }
+
+        it 'raises' do
+          expect { get }.to raise_error(Preservation::Client::NotFoundError, /got 404/)
+        end
       end
     end
   end


### PR DESCRIPTION
closes #190

## Why was this change made? 🤔
So that errors cause failures instead of returning the failure information as the body.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


