### PR TITLE
Avoid use of object_id instance variable.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/lib/preservation/client/response_error_formatter.rb
+++ b/lib/preservation/client/response_error_formatter.rb
@@ -13,23 +13,25 @@ module Preservation
         new(response: response, object_id: object_id, client_method_name: client_method_name).format
       end
 
-      attr_reader :req_url, :status_msg, :status_code, :body, :object_id, :client_method_name
-
       def initialize(response:, object_id: nil, client_method_name: nil)
         @req_url = response.env.url
         @status_msg = response.reason_phrase
         @status_code = response.status
         @body = response.body.present? ? response.body : DEFAULT_BODY
-        @object_id = object_id
+        @id = object_id
         @client_method_name = client_method_name
       end
 
       def format
         status_info = status_msg.blank? ? status_code : "#{status_msg} (#{status_code})"
-        object_id_info = " for #{object_id}" if object_id.present?
+        object_id_info = " for #{id}" if id.present?
 
         "Preservation::Client.#{client_method_name}#{object_id_info} got #{status_info} from Preservation at #{req_url}: #{body}"
       end
+
+      private
+
+      attr_reader :req_url, :status_msg, :status_code, :body, :id, :client_method_name
     end
   end
 end

--- a/spec/preservation/client/response_error_formatter_spec.rb
+++ b/spec/preservation/client/response_error_formatter_spec.rb
@@ -24,35 +24,11 @@ RSpec.describe Preservation::Client::ResponseErrorFormatter do
   end
 
   describe '#initialize' do
-    it 'populates status_msg attribute' do
-      expect(formatter.status_msg).to eq(resp_status_msg)
-    end
-
-    it 'populates status_code attribute' do
-      expect(formatter.status_code).to eq(resp_code)
-    end
-
-    it 'populates body attribute' do
-      expect(formatter.body).to eq(resp_body)
-    end
-
-    it 'populates req_url attribute' do
-      expect(formatter.req_url).to eq(resp_env_url)
-    end
-
-    it 'populates object_id attribute' do
-      expect(formatter.object_id).to eq(druid)
-    end
-
-    it 'populates client_method_name attribute' do
-      expect(formatter.client_method_name).to eq(method_name)
-    end
-
     context 'with a blank body' do
       let(:response) { instance_double(Faraday::Response, reason_phrase: resp_status_msg, status: resp_code, body: '', env: resp_env) }
 
       it 'sets a default body attribute' do
-        expect(formatter.body).to eq(described_class::DEFAULT_BODY)
+        expect(formatter.send(:body)).to eq(described_class::DEFAULT_BODY)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
```
/opt/app/h2/happy-heron/shared/bundle/ruby/3.4.0/gems/preservation-client-6.2.0/lib/preservation/client/response_error_formatter.rb:16: warning: redefining 'object_id' may cause serious problems
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


