### PR TITLE
Remove per-project config (use global config for org)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment: false
-coverage:
-  status:
-    project: true


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


