### PR TITLE
Loosen activesupport pin to allow Rails 8 upgrades

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     preservation-client (7.0.2)
-      activesupport (>= 4.2, < 8)
+      activesupport (>= 4.2)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
       zeitwerk (~> 2.1)
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.1)
+    activesupport (8.0.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -22,6 +22,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -50,7 +51,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
-    logger (1.6.5)
+    logger (1.6.6)
     method_source (1.1.0)
     minitest (5.25.4)
     moab-versioning (6.1.0)

--- a/preservation-client.gemspec
+++ b/preservation-client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'activesupport', '>= 4.2', '< 8'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'moab-versioning', '>= 5.0.0', '< 7'
   spec.add_dependency 'zeitwerk', '~> 2.1'


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


