### PR TITLE
Adds lane_id param to validate_moab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Behavior notes:
 
 ### Validate the Moab
 
-- `client.objects.validate_moab(druid: 'ooo000oo0000')` - validates that the Moab object, used by preservationWF to ensure we have a valid Moab before replicating to various preservation endpoints
+- `client.objects.validate_moab(druid: 'ooo000oo0000', lane_id: 'high)` - validates that the Moab object, used by preservationWF to ensure we have a valid Moab before replicating to various preservation endpoints
 
 ### Get difference information between passed contentMetadata.xml and files in the Moab
 

--- a/lib/preservation/client/objects.rb
+++ b/lib/preservation/client/objects.rb
@@ -118,10 +118,11 @@ module Preservation
       # calls the endpoint to queue a ValidateMoab job for a specific druid
       # typically called by a preservationIngestWF robot
       # @param [String] druid - with or without prefix: 'druid:ab123cd4567' or 'ab123cd4567'
+      # @param [String, nil] lane_id - low, default, or high
       # @return [String] "ok" when job queued
       # @raise [Preservation::Client::NotFoundError] when druid is not found
-      def validate_moab(druid:)
-        get("objects/#{druid}/validate_moab", {}, on_data: nil)
+      def validate_moab(druid:, lane_id: nil)
+        get("objects/#{druid}/validate_moab", { 'lane-id': lane_id }.compact, on_data: nil)
       end
 
       # convenience method for retrieving latest Moab::SignatureCatalog from a Moab object,

--- a/spec/preservation/client/objects_spec.rb
+++ b/spec/preservation/client/objects_spec.rb
@@ -579,13 +579,27 @@ RSpec.describe Preservation::Client::Objects do
   end
 
   describe '#validate_moab' do
-    subject(:request) { client.validate_moab(druid: druid) }
+    subject(:request) { client.validate_moab(druid: druid, lane_id: lane_id) }
 
     let(:druid) { 'oo000oo0000' }
+    let(:lane_id) { nil }
 
     context 'when API request succeeds' do
       before do
         stub_request(:get, "https://prezcat.example.com/objects/#{druid}/validate_moab")
+          .to_return(status: 200, body: 'ok', headers: {})
+      end
+
+      it 'returns ok' do
+        expect(request).to eq 'ok'
+      end
+    end
+
+    context 'when API request succeeds with lane' do
+      let(:lane_id) { 'high' }
+
+      before do
+        stub_request(:get, "https://prezcat.example.com/objects/#{druid}/validate_moab?lane-id=high")
           .to_return(status: 200, body: 'ok', headers: {})
       end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/preservation_catalog/issues/2653

## Why was this change made? 🤔
To allow workflow priority to be passed to pres cat.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


